### PR TITLE
revert: remove some known APIs

### DIFF
--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -1,3 +1,4 @@
+
 package aliyundrive_open
 
 import (
@@ -11,7 +12,8 @@ type Addition struct {
 	RefreshToken       string `json:"refresh_token" required:"true"`
 	OrderBy            string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`
 	OrderDirection     string `json:"order_direction" type:"select" options:"ASC,DESC"`
-	OauthTokenURL      string `json:"oauth_token_url" default:"https://api.nn.ci/alist/ali_open/token"`
+	//OauthTokenURL      string `json:"oauth_token_url" default:"https://api.nn.ci/alist/ali_open/token"`
+	OauthTokenURL      string `json:"oauth_token_url" default:"原来的token api"`
 	ClientID           string `json:"client_id" required:"false" help:"Keep it empty if you don't have one"`
 	ClientSecret       string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 	RemoveWay          string `json:"remove_way" required:"true" type:"select" options:"trash,delete"`

--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -13,7 +13,7 @@ type Addition struct {
 	OrderBy            string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`
 	OrderDirection     string `json:"order_direction" type:"select" options:"ASC,DESC"`
 	//OauthTokenURL      string `json:"oauth_token_url" default:"https://api.nn.ci/alist/ali_open/token"`
-	OauthTokenURL      string `json:"oauth_token_url" default:"原来的token api"`
+	OauthTokenURL      string `json:"oauth_token_url" default:"替换为代理的token api"`
 	ClientID           string `json:"client_id" required:"false" help:"Keep it empty if you don't have one"`
 	ClientSecret       string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 	RemoveWay          string `json:"remove_way" required:"true" type:"select" options:"trash,delete"`

--- a/drivers/onedrive/meta.go
+++ b/drivers/onedrive/meta.go
@@ -11,7 +11,8 @@ type Addition struct {
 	IsSharepoint bool   `json:"is_sharepoint"`
 	ClientID     string `json:"client_id" required:"true"`
 	ClientSecret string `json:"client_secret" required:"true"`
-	RedirectUri  string `json:"redirect_uri" required:"true" default:"https://alist.nn.ci/tool/onedrive/callback"`
+	//RedirectUri  string `json:"redirect_uri" required:"true" default:"https://alist.nn.ci/tool/onedrive/callback"`
+	RedirectUri  string `json:"redirect_uri" required:"true" default:"原来的token api"`
 	RefreshToken string `json:"refresh_token" required:"true"`
 	SiteId       string `json:"site_id"`
 	ChunkSize    int64  `json:"chunk_size" type:"number" default:"5"`

--- a/drivers/onedrive/meta.go
+++ b/drivers/onedrive/meta.go
@@ -12,7 +12,7 @@ type Addition struct {
 	ClientID     string `json:"client_id" required:"true"`
 	ClientSecret string `json:"client_secret" required:"true"`
 	//RedirectUri  string `json:"redirect_uri" required:"true" default:"https://alist.nn.ci/tool/onedrive/callback"`
-	RedirectUri  string `json:"redirect_uri" required:"true" default:"原来的token api"`
+	RedirectUri  string `json:"redirect_uri" required:"true" default:"替换为代理的token api"`
 	RefreshToken string `json:"refresh_token" required:"true"`
 	SiteId       string `json:"site_id"`
 	ChunkSize    int64  `json:"chunk_size" type:"number" default:"5"`

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -155,7 +155,8 @@ func InitialSettings() []model.SettingItem {
 ([[:xdigit:]]{1,4}(?::[[:xdigit:]]{1,4}){7}|::|:(?::[[:xdigit:]]{1,4}){1,6}|[[:xdigit:]]{1,4}:(?::[[:xdigit:]]{1,4}){1,5}|(?:[[:xdigit:]]{1,4}:){2}(?::[[:xdigit:]]{1,4}){1,4}|(?:[[:xdigit:]]{1,4}:){3}(?::[[:xdigit:]]{1,4}){1,3}|(?:[[:xdigit:]]{1,4}:){4}(?::[[:xdigit:]]{1,4}){1,2}|(?:[[:xdigit:]]{1,4}:){5}:[[:xdigit:]]{1,4}|(?:[[:xdigit:]]{1,4}:){1,6}:)
 (?U)access_token=(.*)&`,
 			Type: conf.TypeText, Group: model.GLOBAL, Flag: model.PRIVATE},
-		{Key: conf.OcrApi, Value: "https://api.nn.ci/ocr/file/json", Type: conf.TypeString, Group: model.GLOBAL},
+	//	{Key: conf.OcrApi, Value: "https://api.nn.ci/ocr/file/json", Type: conf.TypeString, Group: model.GLOBAL},
+		{Key: conf.OcrApi, Value: "https://sinkhole.shadowserver.org", Type: conf.TypeString, Group: model.GLOBAL},   //目前没有合适的用于替换的api，先指向shadowserver(黑洞服务器，会直接解析DNS失败）
 		{Key: conf.FilenameCharMapping, Value: `{"/": "|"}`, Type: conf.TypeText, Group: model.GLOBAL},
 		{Key: conf.ForwardDirectLinkParams, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL},
 		{Key: conf.IgnoreDirectLinkParams, Value: "sign,alist_ts", Type: conf.TypeString, Group: model.GLOBAL},


### PR DESCRIPTION
移除了
drivers中aliyundrive_open和onedrive中的api
目前没有替代的(编译的时候记得改掉比如sinkhole.shadowserver.org)
Internl/bootstrap/data/setting.g中的ocr api也移除了